### PR TITLE
link DOIs against preferred resolver

### DIFF
--- a/dupart.cls
+++ b/dupart.cls
@@ -649,7 +649,7 @@
 
 \let\@doi\relax
 
-\def\doi@base{http://dx.doi.org/}
+\def\doi@base{https://doi.org/}
 
 % arXiv
 


### PR DESCRIPTION
Hello!

The DOI foundation recommends a [new, secure resolver](https://www.doi.org/doi_handbook/3_Resolution.html#3.8).

Cheers :-)